### PR TITLE
chore: update bytes and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `bytemuck` from 1.24.0 to 1.25.0 (PR #79).
 - Updated `zerocopy` from 0.8.34 to 0.8.37 (PR #79).
 - Updated `clap` from 4.5.54 to 4.5.56 (PR #79).
+- Updated `bytes` from 1.10.1 to 1.11.1 (PR #83, Dependabot alert #1).
+- Updated quick-start docs to use the crate `Result` alias (PR #84).
 
 ## [0.5.2] - 2026-01-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"

--- a/book/front_matter/10_quick_start.md
+++ b/book/front_matter/10_quick_start.md
@@ -100,25 +100,20 @@ If the program does not compile:
 OctaIndex3D now includes a complete autonomous 3D mapping stack. Here's a quick taste:
 
 ```rust
-use octaindex3d::occupancy::{OccupancyLayer, OccupancyConfig};
-use octaindex3d::exploration::{FrontierDetectionConfig, InformationGainConfig};
+use octaindex3d::layers::{
+    FrontierDetectionConfig, InformationGainConfig, OccupancyLayer,
+};
+use octaindex3d::Result;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<()> {
     // 1. Create an occupancy map
-    let config = OccupancyConfig {
-        resolution: 0.1,  // 10cm voxels
-        prob_hit: 0.7,
-        prob_miss: 0.4,
-        clamp_min: 0.12,
-        clamp_max: 0.97,
-    };
-
-    let mut layer = OccupancyLayer::new(config)?;
+    let voxel_size = 0.1; // 10cm voxels
+    let mut layer = OccupancyLayer::with_thresholds(0.7, 0.3, 0.97);
 
     // 2. Integrate a depth sensor measurement
     let sensor_pos = (0.0, 0.0, 0.0);
     let obstacle_pos = (5.0, 2.0, 1.0);
-    layer.integrate_ray(sensor_pos, obstacle_pos)?;
+    layer.integrate_ray(sensor_pos, obstacle_pos, voxel_size, 0.6, 0.7)?;
 
     // 3. Detect frontiers (boundaries between known and unknown space)
     let frontier_config = FrontierDetectionConfig {

--- a/book/part4_applications/chapter10_robotics_and_autonomy.md
+++ b/book/part4_applications/chapter10_robotics_and_autonomy.md
@@ -1109,7 +1109,7 @@ This design gives you **flexibility**, **composability**, and **control**.
 Frontiers are the boundaries between known free space and unknown space—exactly where you want to explore next.
 
 ```rust
-use octaindex3d::exploration::FrontierDetectionConfig;
+use octaindex3d::layers::FrontierDetectionConfig;
 
 let config = FrontierDetectionConfig {
     min_cluster_size: 10,     // At least 10 voxels per frontier
@@ -1135,7 +1135,7 @@ for frontier in &frontiers {
 Not all viewpoints are equally valuable. Information gain quantifies how much unknown space you'd observe.
 
 ```rust
-use octaindex3d::exploration::InformationGainConfig;
+use octaindex3d::layers::InformationGainConfig;
 
 let ig_config = InformationGainConfig {
     sensor_range: 5.0,                      // 5m depth camera


### PR DESCRIPTION
## Summary
- Update `bytes` to 1.11.1 to address Dependabot alert #1 (CVE-2026-25541).
- Align quick-start docs with the crate `Result` alias.
- Update changelog for PRs #83 and #84.

## Testing
- `cargo test -q` (timed out after 120s; `layers::esdf::tests::test_esdf_from_tsdf` exceeded 60s).
