### PR TITLE
fix: resolve CodeQL workflow permissions alert

### DIFF
--- a/.github/workflows/book-quality.yml
+++ b/.github/workflows/book-quality.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   book-quality:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Added explicit `GITHUB_TOKEN` least-privilege permissions (`contents: read`) to the book-quality GitHub Actions workflow to resolve open CodeQL security alert #23.
+
 ## [0.5.3] - 2026-02-06
 
 ### Changed


### PR DESCRIPTION
## Summary
- add explicit top-level permissions block to .github/workflows/book-quality.yml
- set least privilege to contents: read for GITHUB_TOKEN
- update changelog under [Unreleased]

## Security
- addresses open CodeQL alert #23 (actions/missing-workflow-permissions)

## Validation
- ./scripts/safe_local_test.sh --skip-advisories