### PR TITLE
ci: pin GitHub Actions SHAs and harden repo settings alignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default ownership for repository changes
+* @FunKite
+
+# Security-sensitive paths requiring explicit owner review
+/.github/workflows/ @FunKite
+/scripts/ @FunKite
+/Cargo.toml @FunKite
+/Cargo.lock @FunKite
+/CHANGELOG.md @FunKite

--- a/.github/workflows/book-quality.yml
+++ b/.github/workflows/book-quality.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Verify version matches tag
         run: |
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Extract version
         id: extract-version
@@ -54,7 +54,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           tag_name: ${{ github.ref }}
           name: Release v${{ steps.extract-version.outputs.version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -217,6 +217,8 @@ jobs:
 
       - name: Install Rust 1.77
         uses: dtolnay/rust-toolchain@0ed6b4757d4e63d7920abe758134858e95c8215f
+        with:
+          toolchain: 1.77.0
 
       - name: Check with MSRV
         run: cargo check --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -177,7 +177,7 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   audit:
-    name: Security Audit
+    name: Rust Security Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,27 +23,27 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
         with:
           toolchain: ${{ matrix.rust }}
 
       - name: Cache cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo build
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -61,10 +61,10 @@ jobs:
     name: Feature Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Test hilbert feature
         run: cargo test --verbose --features hilbert
@@ -93,10 +93,10 @@ jobs:
             feature: gpu-vulkan
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Test ${{ matrix.feature }} feature
         run: cargo test --verbose --no-run --features ${{ matrix.feature }}
@@ -108,10 +108,10 @@ jobs:
     name: Example Compilation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Build occupancy_fusion example
         run: cargo build --example occupancy_fusion --verbose
@@ -138,10 +138,10 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
         with:
           components: clippy
 
@@ -152,10 +152,10 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
         with:
           components: rustfmt
 
@@ -166,10 +166,10 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Build documentation
         run: cargo doc --no-deps --all-features
@@ -180,10 +180,10 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -195,10 +195,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Build (debug)
         run: cargo build --verbose
@@ -213,10 +213,10 @@ jobs:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust 1.77
-        uses: dtolnay/rust-toolchain@1.77.0
+        uses: dtolnay/rust-toolchain@0ed6b4757d4e63d7920abe758134858e95c8215f
 
       - name: Check with MSRV
         run: cargo check --all-features

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,10 +26,10 @@ jobs:
           - advisories
           - bans licenses sources
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979
         with:
           command: check ${{ matrix.checks }}
           arguments: --all-features
@@ -38,10 +38,10 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -53,10 +53,10 @@ jobs:
     name: Outdated Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Install cargo-outdated
         run: cargo install cargo-outdated

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
           arguments: --all-features
 
   audit:
-    name: Security Audit
+    name: Security Workflow Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `.github/CODEOWNERS` ownership rules for workflow, script, lockfile, and release-sensitive paths.
 - Renamed duplicate CI check contexts to unique names (`Rust Security Audit`, `Security Workflow Audit`) to avoid branch-protection ambiguity.
 - Updated repository workflow guidance to require short-lived branches from `origin/main` and PR-based merges.
+- Restored explicit MSRV toolchain input (`1.77.0`) in Rust CI after action SHA pinning to prevent implicit channel drift.
 - Updated `glam` from 0.31.0 to 0.32.0 (PR #92).
 - Updated `clap` from 4.5.57 to 4.5.58 (PR #91).
 - Updated `rkyv` from 0.8.14 to 0.8.15 (PR #91).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added explicit `GITHUB_TOKEN` least-privilege permissions (`contents: read`) to the book-quality GitHub Actions workflow to resolve open CodeQL security alert #23.
+- Updated GitHub Actions workflow action references to full commit SHAs across CI/release/security workflows to support strict Actions SHA pinning and reduce supply-chain risk.
+- Updated `glam` from 0.31.0 to 0.32.0 (PR #92).
+- Updated `clap` from 4.5.57 to 4.5.58 (PR #91).
+- Updated `rkyv` from 0.8.14 to 0.8.15 (PR #91).
 - Updated GitHub Actions `actions/checkout` from v4 to v6 (PR #87).
 - Updated `rand` from 0.9 to 0.10 (PR #89).
 - Updated `proptest` from 1.9 to 1.10 (PR #88).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added explicit `GITHUB_TOKEN` least-privilege permissions (`contents: read`) to the book-quality GitHub Actions workflow to resolve open CodeQL security alert #23.
 - Updated GitHub Actions workflow action references to full commit SHAs across CI/release/security workflows to support strict Actions SHA pinning and reduce supply-chain risk.
+- Added `.github/CODEOWNERS` ownership rules for workflow, script, lockfile, and release-sensitive paths.
+- Renamed duplicate CI check contexts to unique names (`Rust Security Audit`, `Security Workflow Audit`) to avoid branch-protection ambiguity.
+- Updated repository workflow guidance to require short-lived branches from `origin/main` and PR-based merges.
 - Updated `glam` from 0.31.0 to 0.32.0 (PR #92).
 - Updated `clap` from 4.5.57 to 4.5.58 (PR #91).
 - Updated `rkyv` from 0.8.14 to 0.8.15 (PR #91).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,10 @@ We actively welcome your pull requests! See [Pull Request Process](#pull-request
 
 ## Pull Request Process
 
-1. **Create a feature branch** from `main`:
+1. **Create a short-lived feature branch** from the latest upstream `main`:
    ```bash
-   git checkout -b feature/your-feature-name
+   git fetch upstream main
+   git checkout -b feature/your-feature-name upstream/main
    ```
 
 2. **Make your changes**:
@@ -147,6 +148,7 @@ We actively welcome your pull requests! See [Pull Request Process](#pull-request
    - At least one maintainer approval
    - No unresolved review comments
    - Branch up to date with main
+   - Merge via pull request only (no direct pushes to `main`)
 
 ## Coding Standards
 


### PR DESCRIPTION
## Summary
- pin all GitHub Actions workflow action references to full commit SHAs
- update CHANGELOG.md under [Unreleased] for workflow hardening and merged dependency updates
- align CI with repository Actions policy requiring SHA-pinned actions

## Security
- reduces third-party action supply-chain risk by removing mutable tag references
- keeps workflows compatible with selected-actions plus SHA-pinning enforcement

## Validation
- verified all workflow action references are pinned to 40-character SHAs
