### PR TITLE
fix: use wrapping checksum in hotspot example

### DIFF
--- a/examples/profile_hotspots.rs
+++ b/examples/profile_hotspots.rs
@@ -236,12 +236,10 @@ fn profile_neighbor_operations() {
     let mut total = 0u64;
     for _ in 0..10_000_000 {
         let neighbors = neighbors_route64_fast(single);
-        total = total.wrapping_add(
-            neighbors
-                .iter()
-                .map(|neighbor| neighbor.value())
-                .sum::<u64>(),
-        );
+        let checksum = neighbors
+            .iter()
+            .fold(0u64, |acc, neighbor| acc.wrapping_add(neighbor.value()));
+        total = total.wrapping_add(checksum);
     }
     let elapsed = start.elapsed();
     println!(


### PR DESCRIPTION
## Summary
- replace the inner neighbor checksum sum with explicit wrapping accumulation
- prevent debug-profile overflow when running the profiling example
- address the review comment left on the earlier maintenance PR

## Validation
- cargo check --all-features --examples