### PR TITLE
ci: reduce overlapping Dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      semver-minor-days: 7
+      semver-patch-days: 3
     open-pull-requests-limit: 5
     reviewers:
       - "FunKite"
@@ -15,14 +18,20 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    # Group minor and patch updates together
+    # Slow routine version PRs slightly so security PRs do not race them,
+    # and group each update class to reduce PR noise.
     groups:
       rust-dependencies:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
+      rust-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `lz4_flex` from 0.12.0 to 0.13.0 to address Dependabot alert #2 / CVE-2026-32829 and incorporate the upstream decompression fix.
 - Updated `once_cell` from 1.21.3 to 1.21.4 and `clap` from 4.5.60 to 4.6.0 (supersedes open PRs #103 and #104).
 - Updated `softprops/action-gh-release` from 2.5.0 to 2.6.1 in the release workflow (supersedes open PR #102).
+- Tuned Dependabot Cargo update handling with a version-update cooldown and explicit security-update grouping to reduce overlapping PR noise.
 
 ## [0.5.4] - 2026-03-12
 


### PR DESCRIPTION
## Summary
- add a short cooldown for Cargo version updates so routine bumps do not race security PRs
- add an explicit Cargo security-updates group so future alerts consolidate more cleanly
- update CHANGELOG.md under Unreleased

## Why
This reduces the chance of duplicate PRs like the concurrent lz4_flex 0.12.1 security fix and 0.13.0 version bump.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'