### PR TITLE
deps: clear rand advisory from Cargo.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Updated `sha2` from 0.10.9 to 0.11.0 and raised `rand` to 0.10.1 to clear the active `RUSTSEC-2026-0097` advisory affecting `cargo-deny`.
+- Updated `sha2` from 0.10.9 to 0.11.0, kept the direct CLI `rand` dependency on 0.10.1, and refreshed the `proptest` lockfile path from `rand` 0.9.2 to 0.9.3 to clear `RUSTSEC-2026-0097` / `GHSA-cq8v-f236-94qc`.
 - Updated GitHub Actions `softprops/action-gh-release` from 2.6.1 to 3.0.0, `EmbarkStudios/cargo-deny-action` from 2.0.15 to 2.0.16, and `actions/cache` from 5.0.4 to 5.0.5.
 - Updated `lz4_flex` from 0.12.0 to 0.13.0 to address Dependabot alert #2 / CVE-2026-32829 and incorporate the upstream decompression fix.
 - Updated `once_cell` from 1.21.3 to 1.21.4 and `clap` from 4.5.60 to 4.6.0 (supersedes open PRs #103 and #104).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",


### PR DESCRIPTION
## Summary
- update the transitive  lockfile entry used by  from 0.9.2 to 0.9.3
- keep the existing direct  0.10.1 dependency and correct the changelog note
- clear GitHub Dependabot alert 

## Validation
- ==> Preflight: dependency diffs
No local dependency file changes detected.
==> Preflight: scrub common credential env vars
==> Security check: cargo deny advisories
==> Running tests

running 136 tests
test compression::tests::test_no_compression ... ok
test container::tests::test_container_rejects_excessive_frame_count ... ok
test container::tests::test_container_rejects_oversized_frame_header ... ok
test frame::tests::test_default_frame ... ok
test compression::tests::test_lz4_roundtrip ... ok
test frame::tests::test_frame_conflict ... ok
test id::tests::test_bytes_roundtrip ... ok
test id::tests::test_bech32m_encoding ... ok
test container::tests::test_container_write_read ... ok
test frame::tests::test_idempotent_registration ... ok
test frame::tests::test_frame_registration ... ok
test id::tests::test_cell_id_creation ... ok
test id::tests::test_cell_id_invalid_parity ... ok
test id::tests::test_cell_ordering ... ok
test id::tests::test_negative_coordinates ... ok
test id::tests::test_neighbor_count ... ok
test id::tests::test_parent_child ... ok
test ids::tests::test_bech32m_rejects_invalid_raw_payloads ... ok
test ids::tests::test_galactic128_creation ... ok
test ids::tests::test_bech32m_roundtrip ... ok
test ids::tests::test_galactic128_parity ... ok
test ids::tests::test_index64_hierarchy ... ok
test ids::tests::test_index64_morton ... ok
test ids::tests::test_route64_parity ... ok
test ids::tests::test_route64_signed ... ok
test io::tests::test_dataset_layer_roundtrip ... ok
test lattice::tests::test_children_count ... ok
test lattice::tests::test_distance ... ok
test lattice::tests::test_lattice_coord_creation ... ok
test io::tests::test_geojson_export ... ok
test lattice::tests::test_neighbor_count ... ok
test lattice::tests::test_neighbor_parity ... ok
test lattice::tests::test_parent_child_relationship ... ok
test lattice::tests::test_parity_validation ... ok
test layer::tests::test_aggregation ... ok
test layer::tests::test_aggregation_rejects_nan ... ok
test layer::tests::test_flags ... ok
test layer::tests::test_layer_basic ... ok
test layer::tests::test_rollup_rejects_nan ... ok
test layers::bcc_utils::tests::test_is_valid_bcc ... ok
test layers::bcc_utils::tests::test_max_error ... ok
test layers::bcc_utils::tests::test_physical_to_voxel ... ok
test layers::bcc_utils::tests::test_snap_already_valid ... ok
test layers::bcc_utils::tests::test_snap_mixed_parity ... ok
test layers::esdf::tests::test_edge_lengths ... ok
test layers::esdf::tests::test_esdf_creation ... ok
test layers::exploration::tests::test_frontier_bounding_box ... ok
test layers::exploration::tests::test_frontier_detection_config ... ok
test layers::exploration::tests::test_information_gain_config ... ok
test layers::exploration::tests::test_normalize ... ok
test layers::measurement::tests::test_color_measurement ... ok
test layers::measurement::tests::test_confidence_clamping ... ok
test layers::measurement::tests::test_depth_measurement ... ok
test layers::measurement::tests::test_depth_with_normal ... ok
test layers::measurement::tests::test_occupancy_measurement ... ok
test layers::mesh::tests::test_add_vertex ... ok
test layers::mesh::tests::test_mesh_creation ... ok
test layers::mesh::tests::test_surface_area ... ok
test layers::occupancy::tests::test_bayesian_fusion ... ok
test layers::mesh::tests::test_mesh_extraction ... ok
test layers::occupancy::tests::test_log_odds_conversion ... ok
test layers::occupancy::tests::test_measurement_trait ... ok
test layers::occupancy::tests::test_occupancy_layer_creation ... ok
test layers::occupancy::tests::test_occupancy_update ... ok
test layers::occupancy::tests::test_ray_integration ... ok
test layers::occupancy::tests::test_state_counts ... ok
test layers::occupancy_compressed::tests::test_rle_encoding ... ok
test layers::occupancy_temporal::tests::test_stale_pruning ... ok
test layers::occupancy_compressed::tests::test_compressed_storage ... ok
test layers::export::tests::test_obj_export ... ok
test layers::export::tests::test_ply_ascii_export ... ok
test layers::occupancy_temporal::tests::test_temporal_decay ... ok
test layers::ros2_bridge::tests::test_pointcloud2_creation ... ok
test layers::ros2_bridge::tests::test_ros2_time ... ok
test layers::tests::test_layer_type_names ... ok
test layers::tests::test_layered_map_creation ... ok
test layers::tsdf::tests::test_max_weight_clamping ... ok
test layers::tsdf::tests::test_tsdf_creation ... ok
test layers::tsdf::tests::test_tsdf_incremental_update ... ok
test layers::tsdf::tests::test_tsdf_stats ... ok
test layers::tsdf::tests::test_tsdf_update ... ok
test layers::tsdf::tests::test_wrong_measurement_type ... ok
test morton::tests::test_morton_identity ... ok
test morton::tests::test_morton_lut ... ok
test morton::tests::test_morton_ordering ... ok
test neighbors::tests::test_distance ... ok
test neighbors::tests::test_galactic128_neighbors ... ok
test neighbors::tests::test_index64_neighbors ... ok
test neighbors::tests::test_route64_neighbors ... ok
test path::tests::test_k_shell ... ok
test layers::ros2_bridge::tests::test_occupancy_grid_serialization ... ok
test performance::arch_optimized::tests::test_arch_detection ... ok
test path::tests::test_trace_line ... ok
test performance::arch_optimized::tests::test_batch_with_prefetch ... ok
test performance::arch_optimized::tests::test_prefetch ... ok
test path::tests::test_astar_closed_set_efficiency ... ok
test path::tests::test_k_ring ... ok
test performance::batch::tests::test_batch_neighbor_calculator ... ok
test performance::batch::tests::test_batch_index_builder ... ok
test path::tests::test_astar_simple ... ok
test performance::fast_neighbors::tests::test_batch_neighbors_fast ... ok
test performance::fast_neighbors::tests::test_batch_neighbors_small ... ok
test performance::fast_neighbors::tests::test_fast_neighbors ... ok
test performance::fast_neighbors::tests::test_fast_neighbors_respect_route64_bounds ... ok
test performance::memory::tests::test_aligned_batch_processor ... ok
test performance::memory::tests::test_aligned_vec ... ok
test performance::memory::tests::test_memory_analyzer ... ok
test performance::memory::tests::test_numa_detection ... ok
test performance::morton_batch::tests::test_batch_morton_decode ... ok
test layers::bcc_utils::tests::test_snap_error_bound ... ok
test performance::memory::tests::test_sequential_prefetcher ... ok
test performance::morton_batch::tests::test_batch_morton_encode ... ok
test performance::morton_batch::tests::test_batch_morton_roundtrip ... ok
test performance::parallel::tests::test_should_use_parallel ... ok
test performance::fast_neighbors::tests::test_batch_neighbors_auto ... ok
test performance::fast_neighbors::tests::test_batch_neighbors_medium ... ok
test performance::simd::tests::test_batch_index64_new_simd ... ok
test performance::simd::tests::test_batch_neighbors_simd ... ok
test performance::simd::tests::test_simd_availability ... ok
test performance::simd_batch::tests::test_batch_bounding_box_query ... ok
test performance::simd_batch::tests::test_batch_bounding_box_query_large ... ok
test performance::simd_batch::tests::test_batch_euclidean_distance_squared ... ok
test performance::morton_batch::tests::test_batch_morton_large ... ok
test performance::simd_batch::tests::test_batch_index64_encode ... ok
test performance::parallel::tests::test_thread_count ... ok
test performance::parallel::tests::test_parallel_index_builder ... ok
test performance::fast_neighbors::tests::test_neighbor_stream ... ok
test performance::simd_batch::tests::test_batch_index64_decode ... ok
test performance::simd_batch::tests::test_batch_validate_routes ... ok
test performance::simd_batch::tests::test_batch_manhattan_distance ... ok
test performance::tests::test_backend_selection ... ok
test tests::test_basic_id_creation ... ok
test tests::test_bcc_neighbors ... ok
test tests::test_version ... ok
test path::tests::test_astar_expansion_limit ... ok
test performance::parallel::tests::test_parallel_neighbor_calculator ... ok

test result: ok. 136 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s


running 12 tests
test src/layers/export.rs - layers::export::export_mesh_obj (line 159) - compile ... ok
test src/layers/ros2_bridge.rs - layers::ros2_bridge (line 9) - compile ... ok
test src/layers/export.rs - layers::export::export_mesh_ply (line 23) - compile ... ok
test src/layers/measurement.rs - layers::measurement::Measurement::depth (line 76) ... ok
test src/layers/occupancy_compressed.rs - layers::occupancy_compressed::CompressedOccupancyLayer (line 42) ... ok
test src/layers/occupancy.rs - layers::occupancy::OccupancyLayer (line 69) ... ok
test src/layers/bcc_utils.rs - layers::bcc_utils::snap_to_nearest_bcc (line 16) ... ok
test src/layers/bcc_utils.rs - layers::bcc_utils::physical_to_bcc_voxel (line 108) ... ok
test src/layers/mod.rs - layers (line 14) ... ok
test src/layers/esdf.rs - layers::esdf::ESDFLayer::new (line 91) ... ok
test src/layers/tsdf.rs - layers::tsdf::TSDFLayer::new (line 73) ... ok
test src/lib.rs - (line 21) ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.74s

==> Safe local test run complete

## Notes
-  still reports a local parsing limitation with CVSS 4.0 advisory metadata, so the script correctly downgraded that advisory-db issue to a warning while continuing with tests.