### PR TITLE
deps(deps): refresh dependency PR queue

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb
         with:
           command: check ${{ matrix.checks }}
           arguments: --all-features
@@ -59,7 +59,7 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Install cargo-outdated
-        run: cargo install cargo-outdated
+        run: cargo install cargo-outdated --locked
 
       - name: Check for outdated dependencies
         run: cargo outdated --exit-code 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Updated `clap` from 4.6.0 to 4.6.1, `EmbarkStudios/cargo-deny-action` from 2.0.16 to 2.0.17, regenerated the lockfile with Cargo's current transitive `windows-sys` resolution, and pinned the `cargo-outdated` CI install to its lockfile to keep the outdated-dependency check compatible with the current stable toolchain (supersedes open PRs #119 and #120).
 - Updated `sha2` from 0.10.9 to 0.11.0, kept the direct CLI `rand` dependency on 0.10.1, and refreshed the `proptest` lockfile path from `rand` 0.9.2 to 0.9.3 to clear `RUSTSEC-2026-0097` / `GHSA-cq8v-f236-94qc`.
 - Updated GitHub Actions `softprops/action-gh-release` from 2.6.1 to 3.0.0, `EmbarkStudios/cargo-deny-action` from 2.0.15 to 2.0.16, and `actions/cache` from 5.0.4 to 5.0.5.
 - Updated `lz4_flex` from 0.12.0 to 0.13.0 to address Dependabot alert #2 / CVE-2026-32829 and incorporate the upstream decompression fix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -616,7 +616,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -686,7 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1807,7 +1807,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2018,7 +2018,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update pinned EmbarkStudios/cargo-deny-action from 2.0.16 to 2.0.17
- update clap lockfile entries from 4.6.0 to 4.6.1 and regenerate Cargo.lock with current Cargo resolution
- install cargo-outdated with --locked so the Outdated Dependencies job does not pull transitive crates requiring rustc 1.93 on the current stable runner

Supersedes Dependabot PRs #119 and #120.

## Validation
- ./scripts/safe_local_test.sh --allow-network
- cargo check --all-features
- cargo check --locked --all-features
- cargo install cargo-outdated --locked --version 0.19.0 --root /tmp/octa-cargo-outdated-check

## Notes
- The local cargo-deny advisory step still warns on CVSS 4.0 advisory metadata with the installed local cargo-deny; safe_local_test.sh treats that known parser limitation as non-blocking.