### PR TITLE
docs(changelog): record wgpu 29.0.3 and cargo-deny-action 2.0.18 merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Updated `wgpu` from 29.0.2 to 29.0.3; 29.0.2 was yanked upstream due to a compilation error when `cfg(debug_assertions)` is not active (PR #125).
+- Updated `EmbarkStudios/cargo-deny-action` from 2.0.17 to 2.0.18, which bumps the bundled `cargo-deny` to 0.19.5 (PR #124).
 - Updated `rkyv` from 0.8.15 to 0.8.16, `rayon` from 1.11.0 to 1.12.0, and `wgpu` from 29.0.1 to 29.0.2.
 - Updated `clap` from 4.6.0 to 4.6.1, `EmbarkStudios/cargo-deny-action` from 2.0.16 to 2.0.17, regenerated the lockfile with Cargo's current transitive `windows-sys` resolution, and pinned the `cargo-outdated` CI install to its lockfile to keep the outdated-dependency check compatible with the current stable toolchain (supersedes open PRs #119 and #120).
 - Updated `sha2` from 0.10.9 to 0.11.0, kept the direct CLI `rand` dependency on 0.10.1, and refreshed the `proptest` lockfile path from `rand` 0.9.2 to 0.9.3 to clear `RUSTSEC-2026-0097` / `GHSA-cq8v-f236-94qc`.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Merged Dependabot PR #124: `EmbarkStudios/cargo-deny-action` 2.0.17 → 2.0.18 (bumps bundled `cargo-deny` to 0.19.5); all CI checks passed.
- Merged Dependabot PR #125: `wgpu` 29.0.2 → 29.0.3; upstream yanked 29.0.2 due to a compilation error when `cfg(debug_assertions)` is inactive — this is a stability/correctness fix; all CI checks passed.
- Updated `CHANGELOG.md` `[Unreleased]` section to document both merges.

## Test plan

- [ ] Confirm both Dependabot PRs (#124, #125) appear as merged on GitHub.
- [ ] Review the two new `[Unreleased]` CHANGELOG lines for accuracy.
- [ ] CI passes on this branch (CHANGELOG-only change, no code delta).

https://claude.ai/code/session_01WfFAXEAYPH8CsCQVwypHQb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfFAXEAYPH8CsCQVwypHQb)_