### PR TITLE
chore: prepare v0.5.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-05-19
+
 ### Security
 - Updated `lz4_flex` from 0.13.0 to 0.13.1 (PR #127): fixes an out-of-bounds read / panic when compressing with dictionaries shorter than 4 bytes in `unsafe` mode — this is a security fix for untrusted-dictionary scenarios; all users on 0.13.0 should upgrade.
 
@@ -24,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated pinned `actions/cache` from 5.0.3 to 5.0.4 in the Rust CI workflow (refreshes open PR #107 onto current `main`).
 - Updated `wgpu` from 28.0.0 to 29.0.0 and adjusted the compute backend for the upstream API changes (supersedes open PR #108).
 - Tuned Dependabot Cargo update handling with a version-update cooldown and explicit security-update grouping to reduce overlapping PR noise.
+
+### Fixed
+- Restored `--no-default-features` builds by gating legacy serialization derives and I/O helpers behind the `serde` feature.
+- Excluded local release archives and replay/demo artifacts from the crates.io package.
 
 ## [0.5.4] - 2026-03-12
 
@@ -253,7 +259,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Morton decode optimization (37% speedup)
 - Parallel overhead fix (86% speedup for 10K batches)
 
-[Unreleased]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/FunKite/OctaIndex3D/releases/tag/v0.5.4
 [0.5.3]: https://github.com/FunKite/OctaIndex3D/releases/tag/v0.5.3
 [0.5.2]: https://github.com/FunKite/OctaIndex3D/releases/tag/v0.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "octaindex3d"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "ahash",
  "aligned-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octaindex3d"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 rust-version = "1.77"
 authors = ["Michael A. McLarney"]
@@ -21,6 +21,11 @@ exclude = [
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".cargo/",
     "deny.toml",
+    "release-artifacts/",
+    "replay*.json",
+    "octahedron_image.html",
+    "octahedron_still.html",
+    "Truncated Octahedron.png",
     "rust-toolchain.toml",
     "workinprogress.txt",
 ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Table of Contents
 
-- [What's New in v0.5.4](#whats-new-in-v054)
+- [What's New in v0.5.5](#whats-new-in-v055)
 - [Overview](#overview)
 - [Why BCC Lattice?](#why-bcc-lattice)
 - [Interactive 3D Maze Game](#-interactive-3d-maze-game)
@@ -35,14 +35,15 @@
 - [Contributing](#contributing)
 - [Research and Citation](#research-and-citation)
 
-## What's New in v0.5.4
+## What's New in v0.5.5
 
-This release focuses on patch-level dependency updates, security hardening, and safer release operations.
+This release focuses on security dependency updates, GPU dependency compatibility, and release metadata cleanup.
 
-- **Dependency refresh** - Updated `glam`, `rand`, `proptest`, `criterion`, `clap`, `rkyv`, `cudarc`, `zerocopy`, and `getrandom` across runtime and test surfaces.
-- **Security and robustness fixes** - Restored Route64 boundary filtering, hardened Bech32 payload validation, added Metal bounds checks, and made CLI raw-mode cleanup reliable on early exit.
-- **CI and repository hardening** - Pinned GitHub Actions SHAs, added `CODEOWNERS`, clarified unique security check contexts, and tightened workflow permissions.
-- **Release process correction** - The repo release flow now expects `cargo publish --dry-run` and real `cargo publish` to complete before the `v0.5.4` tag is pushed.
+- **Security dependency fix** - Updated `lz4_flex` to 0.13.1 to avoid an upstream unsafe-mode dictionary compression panic for short dictionaries.
+- **GPU dependency refresh** - Updated `cudarc` to 0.19.7 and `wgpu` to 29.0.3, including the replacement for the yanked `wgpu` 29.0.2 release.
+- **Runtime and tooling updates** - Refreshed `rkyv`, `rayon`, `clap`, Cargo lockfile resolution, and GitHub Actions dependency tooling.
+- **Feature build fix** - Restored `--no-default-features` builds by keeping legacy serialization helpers behind the `serde` feature.
+- **Release metadata cleanup** - Promoted the accumulated unreleased dependency notes into the v0.5.5 changelog before publishing to crates.io.
 
 See the full [Changelog](CHANGELOG.md) for release history.
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -8,6 +8,7 @@
 use crate::error::{Error, Result};
 use crate::lattice::{Lattice, LatticeCoord, Parity};
 use bech32::{Bech32m, Hrp};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -40,7 +41,8 @@ pub const FORMAT_VERSION: u8 = 2;
 /// ## Coordinate Range:
 /// - v0.1: ±8.4 million per axis
 /// - v0.2: ±2.1 billion per axis (supports Earth-scale in meters!)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CellID {
     /// Raw 128-bit value
     value: u128,

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -5,6 +5,7 @@
 use crate::error::{Error, Result};
 use crate::id::CellID;
 use rustc_hash::FxHashMap;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -26,7 +27,8 @@ pub enum Aggregation {
 }
 
 /// Generic data layer for storing cell attributes
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Layer<T> {
     /// Name of this layer
     name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod geojson;
 
 // Legacy modules (for compatibility)
 pub mod id;
+#[cfg(feature = "serde")]
 pub mod io;
 pub mod layer;
 pub mod path;
@@ -108,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(VERSION, "0.5.4");
+        assert_eq!(VERSION, "0.5.5");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bump crate metadata to 0.5.5
- promote unreleased dependency/security notes into the v0.5.5 changelog and refresh README release notes
- restore no-default feature builds by gating legacy serde-dependent APIs
- exclude local release/replay/demo artifacts from the crates.io package

## Validation
- ./scripts/safe_local_test.sh --allow-network
- cargo test --locked --all-features -- --skip layers::esdf::tests::test_esdf_from_tsdf
- cargo test --locked --no-default-features
- cargo package --locked
- cargo publish --dry-run --locked

## Package review
- packaged 87 files, 787.5KiB uncompressed, 185.6KiB compressed