### PR TITLE
security: replace unmaintained serde_cbor with ciborium (RUSTSEC-2021-0127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Replaced unmaintained `serde_cbor` (RUSTSEC-2021-0127) with `ciborium 0.2` in the `serde` feature; the public `Dataset::save_cbor` / `Dataset::load_cbor` API is preserved with identical behaviour.
+- Removed `RUSTSEC-2021-0127` from `deny.toml` advisory ignore list now that the advisory no longer applies.
+- Routine security audit (2026-05-20): no new CVEs or active advisories in the dependency tree; `paste` (RUSTSEC-2024-0436, unmaintained, transitive via `metal`) remains the sole acknowledged advisory.
+
 ## [0.5.5] - 2026-05-19
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.7.1",
+ "half",
 ]
 
 [[package]]
@@ -889,12 +889,6 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
-name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
@@ -1194,7 +1188,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
- "half 2.7.1",
+ "half",
  "hashbrown 0.16.0",
  "hexf-parse",
  "indexmap",
@@ -1307,6 +1301,7 @@ dependencies = [
  "approx",
  "bech32",
  "bytemuck",
+ "ciborium",
  "clap",
  "crc32fast",
  "criterion",
@@ -1329,7 +1324,6 @@ dependencies = [
  "rkyv",
  "rustc-hash 2.1.2",
  "serde",
- "serde_cbor",
  "serde_json",
  "sha2",
  "thiserror",
@@ -1863,16 +1857,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half 1.8.3",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zstd = { version = "0.13", optional = true }
 # Serialization
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
-serde_cbor = { version = "0.11", optional = true }
+ciborium = { version = "0.2", optional = true }
 
 # Bech32m encoding
 bech32 = "0.11"
@@ -138,7 +138,7 @@ rand = "0.10.1"
 default = ["serde", "lz4", "simd", "parallel"]
 lz4 = []
 zstd = ["dep:zstd"]
-serde = ["dep:serde", "dep:serde_json", "dep:serde_cbor"]
+serde = ["dep:serde", "dep:serde_json", "dep:ciborium"]
 pathfinding = ["dep:petgraph"]
 zerocopy_support = ["dep:zerocopy"]
 rkyv = ["dep:rkyv"]

--- a/deny.toml
+++ b/deny.toml
@@ -6,9 +6,8 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# Ignore serde_cbor unmaintained warning (dev dependency via criterion)
-# Ignore paste unmaintained warning (used by metal and wgpu-hal dependencies)
-ignore = ["RUSTSEC-2021-0127", "RUSTSEC-2024-0436"]
+# Ignore paste unmaintained warning (transitive via metal / wgpu-hal; no direct replacement available)
+ignore = ["RUSTSEC-2024-0436"]
 
 [licenses]
 # Allow commonly used licenses for Rust projects

--- a/src/io.rs
+++ b/src/io.rs
@@ -100,7 +100,7 @@ impl Dataset {
     pub fn save_cbor<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let file = File::create(path)?;
         let writer = BufWriter::new(file);
-        serde_cbor::to_writer(writer, self).map_err(|e| Error::IoError(e.to_string()))?;
+        ciborium::into_writer(self, writer).map_err(|e| Error::IoError(e.to_string()))?;
         Ok(())
     }
 
@@ -108,7 +108,7 @@ impl Dataset {
     pub fn load_cbor<P: AsRef<Path>>(path: P) -> Result<Self> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
-        serde_cbor::from_reader(reader).map_err(|e| Error::IoError(e.to_string()))
+        ciborium::from_reader(reader).map_err(|e| Error::IoError(e.to_string()))
     }
 }
 


### PR DESCRIPTION
## Summary

Routine repository maintenance (2026-05-20):

- **No open PRs or issues** found — repository is in a clean state.
- **Security audit** run against the full dependency tree (308 crates, 1095 advisories): no new CVEs or active vulnerabilities.
- **serde_cbor → ciborium migration** (see below).
- **CHANGELOG.md** updated with `[Unreleased]` entries for this work.

---

## Changes

### Security fix — replace `serde_cbor` with `ciborium`

`serde_cbor` (v0.11) has been unmaintained since 2021 and carries advisory **RUSTSEC-2021-0127**. It was previously suppressed in `deny.toml` rather than replaced.

This PR migrates to **`ciborium 0.2`**, the actively maintained CBOR implementation, with a drop-in API substitution:

| Before | After |
|---|---|
| `serde_cbor::to_writer(writer, &self)` | `ciborium::into_writer(&self, writer)` |
| `serde_cbor::from_reader(reader)` | `ciborium::from_reader(reader)` |

The public `Dataset::save_cbor` / `Dataset::load_cbor` API is fully preserved — no breaking changes.

`RUSTSEC-2021-0127` has been removed from the `deny.toml` ignore list. The only remaining acknowledged advisory is **RUSTSEC-2024-0436** (`paste`, unmaintained, transitive via `metal`) for which no upstream replacement exists.

### Files changed
| File | Change |
|---|---|
| `Cargo.toml` | `serde_cbor 0.11` → `ciborium 0.2`; feature wiring updated |
| `src/io.rs` | Updated CBOR calls to ciborium API |
| `deny.toml` | Removed `RUSTSEC-2021-0127` from ignore list |
| `CHANGELOG.md` | Added `[Unreleased]` entries |

### Test results
```
test result: ok. 142 passed; 0 failed; 0 ignored
Doc-tests: ok. 12 passed; 0 failed
cargo audit: 1 allowed warning (paste/RUSTSEC-2024-0436, transitive, no fix available)
```

https://claude.ai/code/session_01CkECNwSZGk9YcQkvYbiaSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkECNwSZGk9YcQkvYbiaSi)_