### PR TITLE
docs(changelog): record serde_json 1.0.150 and cargo-deny-action 2.0.19 merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `RUSTSEC-2021-0127` from `deny.toml` advisory ignore list now that the advisory no longer applies.
 - Routine security audit (2026-05-20): no new CVEs or active advisories in the dependency tree; `paste` (RUSTSEC-2024-0436, unmaintained, transitive via `metal`) remains the sole acknowledged advisory.
 
+### Changed
+- Updated `serde_json` from 1.0.149 to 1.0.150 (PR #132): rejects non-string enum object keys, closing a subtle deserialization correctness issue.
+- Updated `EmbarkStudios/cargo-deny-action` from 2.0.18 to 2.0.19 (PR #131): bumps the bundled `cargo-deny` to 0.19.7.
+
 ## [0.5.5] - 2026-05-19
 
 ### Security


### PR DESCRIPTION
## Summary

Records the two Dependabot dependency bumps that were just merged into `main`:

| PR | Change | Notes |
|---|---|---|
| #132 | `serde_json` 1.0.149 → 1.0.150 | Rejects non-string enum object keys — deserialization correctness fix |
| #131 | `EmbarkStudios/cargo-deny-action` 2.0.18 → 2.0.19 | Bumps bundled `cargo-deny` to 0.19.7 |

Both PRs had all CI checks green before merging (22/22 checks passed).

## Checklist
- [x] CHANGELOG `[Unreleased]` section updated with `### Changed` entries for both merges
- [x] No source code changes — documentation only
- [x] Branch rebased on top of the two merged commits

https://claude.ai/code/session_01QnbqVQYAWFGJp6eLmMBpRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnbqVQYAWFGJp6eLmMBpRj)_