### PR TITLE
docs(changelog): record dependency update merges (#136–#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Routine security audit (2026-05-20): no new CVEs or active advisories in the dependency tree; `paste` (RUSTSEC-2024-0436, unmaintained, transitive via `metal`) remains the sole acknowledged advisory.
 
 ### Changed
+- Updated `EmbarkStudios/cargo-deny-action` from 2.0.19 to 2.0.20 (PR #137): bumps the bundled `cargo-deny` to 0.19.8.
+- Updated `glam` from 0.32.1 to 0.33.0 (PR #139): all non-`f32`/`bool` vector and matrix types are now optional Cargo features (enabled by default, so the public API is unchanged), and `as_dmat2`/`as_dmat3`/`as_dmat4` gained `#[must_use]`.
+- Updated `zerocopy` from 0.8.48 to 0.8.50 in the `rust-dependencies` group (PR #138).
+- Updated `actions/checkout` from 6.0.2 to 6.0.3 (PR #136): fixes checkout initialization for SHA-256 repositories and expands the merge-commit SHA regex.
 - Updated `serde_json` from 1.0.149 to 1.0.150 (PR #132): rejects non-string enum object keys, closing a subtle deserialization correctness issue.
 - Updated `EmbarkStudios/cargo-deny-action` from 2.0.18 to 2.0.19 (PR #131): bumps the bundled `cargo-deny` to 0.19.7.
 


### PR DESCRIPTION
## Summary

Repository maintenance pass over the open Dependabot pull requests. All four open PRs were reviewed against CI and merged into `main`, and this PR records them in the changelog under `[Unreleased] → Changed`.

### Pull requests addressed (all merged)
- **#136** — `actions/checkout` 6.0.2 → 6.0.3 (CI). All 22 checks green.
- **#137** — `EmbarkStudios/cargo-deny-action` 2.0.19 → 2.0.20 (CI; bundled `cargo-deny` → 0.19.8). 21/22 checks green; the single `Test Suite (windows-latest, beta)` failure was a transient toolchain-setup failure (the job died during `rustup`/cache setup, before any test ran) and is unrelated to a workflow-action version bump.
- **#138** — `zerocopy` 0.8.48 → 0.8.50 (`rust-dependencies` group). All checks green.
- **#139** — `glam` 0.32.1 → 0.33.0 (major bump). Full test suite, build, MSRV, clippy, and security checks all green; the breaking change only makes non-`f32`/`bool` types optional Cargo features (enabled by default), so the public API is unchanged.

### Security
- `Rust Security Audit`, `Cargo Deny (advisories)`, `Cargo Deny (bans licenses sources)`, and `Security Workflow Audit` passed on each merged PR — no new advisories introduced by these updates.

### Changes in this PR
- `CHANGELOG.md`: add four `Changed` entries documenting the merges above.

https://claude.ai/code/session_01Y8ZaYV67hWabWH4eJkVumM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8ZaYV67hWabWH4eJkVumM)_