### PR TITLE
docs(readme): fix Quick Start links pointing to the maze game section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- README: the "Quick Start" table-of-contents entry and the v0.5.6 `BccGrid` highlight linked to `#quick-start`, which resolved to the maze game's install instructions instead of the library quick start. Both now point to the 30-Second Quick Start (the `BccGrid` example), and the game's duplicate "Quick Start" heading is renamed "How to Play".
+
 ## [0.5.6] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Why BCC Lattice?](#why-bcc-lattice)
 - [Interactive 3D Maze Game](#-interactive-3d-maze-game)
 - [Installation](#installation)
-- [Quick Start](#quick-start)
+- [Quick Start](#30-second-quick-start)
 - [ID System Architecture](#id-system-architecture-v030)
 - [Examples](#examples)
 - [Streaming Container Format](#streaming-container-format)
@@ -38,7 +38,7 @@
 
 This release introduces the high-level `BccGrid` API, corrects several BCC lattice operations, and adds a new survival mode to the interactive maze.
 
-- **New `BccGrid` facade** - Convert physical points to cells, query `neighbors`, `k_ring`, `k_shell`, and `distance`, and run A* pathfinding on modern `Route64` IDs without handling parity, tiers, or coordinate ranges manually. See the [Quick Start](#quick-start) and `examples/quickstart.rs`.
+- **New `BccGrid` facade** - Convert physical points to cells, query `neighbors`, `k_ring`, `k_shell`, and `distance`, and run A* pathfinding on modern `Route64` IDs without handling parity, tiers, or coordinate ranges manually. See the [30-Second Quick Start](#30-second-quick-start) and `examples/quickstart.rs`.
 - **Lattice correctness fixes** - `physical_to_lattice` now snaps any finite in-range point to the nearest valid BCC point and honors its `resolution` parameter; `get_children` produces the 8 parity-valid children with `get_parent` as its exact inverse; `batch_validate_routes` applies the correct all-same-parity rule.
 - **Legacy API deprecations** - The v0.2-era `CellID`, `path::*`, and `Layer` APIs are deprecated in favor of `BccGrid` and the modern ID types. All remain available for compatibility.
 - **README doctests** - The README's Rust code blocks now compile as doctests, so documentation examples stay in sync with the implementation.
@@ -141,7 +141,7 @@ Experience the power of BCC lattice pathfinding with our **interactive 3D octahe
 - **Real-time feedback**: See your efficiency compared to the theoretical minimum path
 - **BCC lattice navigation**: Experience true 3D movement with 14-neighbor connectivity
 
-### Quick Start
+### How to Play
 
 ```bash
 # Install the CLI (requires 'cli' feature)


### PR DESCRIPTION
## Summary

The README table-of-contents entry "Quick Start" and the v0.5.6 What's New `BccGrid` highlight both linked to `#quick-start` — but that anchor resolves to the maze game's "Quick Start" heading (install-and-play instructions), not the library example.

- Both links now point to `#30-second-quick-start`, the section with the `BccGrid` code example
- The game's duplicate heading is renamed "How to Play" so the anchors no longer collide
- CHANGELOG entry added under `[Unreleased]`

Rendered README on this branch: [README.md](https://github.com/FunKite/OctaIndex3D/blob/fix/readme-quickstart-anchor/README.md)

README doctests still pass (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)