### PR TITLE
docs(changelog): record rust-dependencies group bump (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `zerocopy` from 0.8.50 to 0.8.52 and `glam` from 0.33.0 to 0.33.1 in the `rust-dependencies` group (PR #145): both are patch-level lockfile bumps with no public API impact; `glam` relaxes the vector `map` closure bound from `Fn` to `FnMut`. All CI, security-audit, and `cargo-deny` checks pass.
+
 ### Fixed
 - README: the "Quick Start" table-of-contents entry and the v0.5.6 `BccGrid` highlight linked to `#quick-start`, which resolved to the maze game's install instructions instead of the library quick start. Both now point to the 30-Second Quick Start (the `BccGrid` example), and the game's duplicate "Quick Start" heading is renamed "How to Play".
 - CHANGELOG: the `[Unreleased]` comparison link still pointed at `v0.5.5...HEAD` and the released `0.5.6` entry had no reference-link definition. The `[Unreleased]` link now compares against `v0.5.6`, and a `[0.5.6]` link (`v0.5.5...v0.5.6`) was added.


### PR DESCRIPTION
## Summary

Routine repository maintenance.

- **Merged PR #145** (Dependabot `rust-dependencies` group): `zerocopy` 0.8.50 → 0.8.52 and `glam` 0.33.0 → 0.33.1. Both are patch-level `Cargo.lock` bumps. All 22 CI checks passed, including Rust Security Audit, Cargo Deny (advisories), and CodeQL.
- **Recorded the merge** in `CHANGELOG.md` under `[Unreleased] → Changed`, matching the project's convention for dependency updates.

## Security

No new CVEs or active advisories introduced. The dependency tree stays current; `cargo-deny` advisory and license checks pass on the merged result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018czJZu4JLyiTQ3ydNBVghC

---
_Generated by [Claude Code](https://claude.ai/code/session_018czJZu4JLyiTQ3ydNBVghC)_