### PR TITLE
docs(changelog): record actions/cache merge (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Updated `actions/cache` from 5.0.5 to 6.1.0 (PR #152): upstream `@actions/cache` v6.1.0 handles cache-write errors caused by read-only tokens. All three pinned `uses: actions/cache@<sha>` references in `rust.yml` were rebased to the new release SHA; the full CI matrix (22 checks) ran green.
 - Updated `bech32` from 0.11.1 to 0.12.0 (PR #150): upstream adds checksum error correction and a const `Hrp::len`, removes an unused argument on `CheckedHrpstring::fe32_iter`, and derives `Default` for `Fe32`. The APIs this crate uses are unchanged; all CI, security-audit, and `cargo-deny` checks pass.
 - Updated the `rust-dependencies` group (PR #149): `cudarc` from 0.19.7 to 0.19.8 (adds CUDA 13.3 support) and `getrandom` from 0.4.2 to 0.4.3 (adds `wasm64-unknown-unknown` support and replaces the `wasip2`/`wasip3` dependencies with manual bindings). Lockfile-only bumps with no public API impact.
 - Updated `actions/checkout` from 6.0.3 to 7.0.0 (PR #148): a major release moving the action runtime to Node 24 that now blocks checking out fork PRs under `pull_request_target`/`workflow_run`. This repository uses neither trigger, so the behavioural change is a no-op here; the full CI matrix runs green on checkout v7.
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CHANGELOG: the `[Unreleased]` comparison link still pointed at `v0.5.5...HEAD` and the released `0.5.6` entry had no reference-link definition. The `[Unreleased]` link now compares against `v0.5.6`, and a `[0.5.6]` link (`v0.5.5...v0.5.6`) was added.
 
 ### Security
+- Routine dependency maintenance (2026-06-30): merged the `actions/cache` Dependabot update (PR #152), pinned by commit SHA matching the upstream v6.1.0 release tag. All 22 CI checks passed, including `Rust Security Audit`, `Cargo Deny` (advisories/bans/licenses/sources), and `CodeQL`.
 - Routine dependency maintenance (2026-06-24): merged the four open Dependabot updates (PRs #147–#150). Each passed the `Rust Security Audit` and `cargo-deny` (advisories/bans/licenses/sources) CI jobs, and `cargo update --locked` confirms the combined `Cargo.lock` is consistent and introduces no new advisories. `paste` (RUSTSEC-2024-0436, unmaintained, transitive via `metal`/`wgpu-hal`) remains the sole acknowledged advisory and stays ignored in `deny.toml`.
 - Routine security audit (2026-06-10): `cargo audit` against the current `Cargo.lock` (308 crate dependencies, 1123 advisories loaded) reports no new CVEs or active advisories. `paste` (RUSTSEC-2024-0436, unmaintained, transitive via `metal`/`wgpu-hal`) remains the sole acknowledged advisory and stays ignored in `deny.toml`.
 


### PR DESCRIPTION
## Summary

Routine repository maintenance. The two open pull requests were reviewed and merged:

| PR | Update | Notes |
|----|--------|-------|
| #151 | `docs(changelog)`: record dependency merges (#147–#150) | Already green across the full CI matrix; merged as-is |
| #152 | `actions/cache` 5.0.5 → 6.1.0 | Pinned by commit SHA matching the upstream v6.1.0 release tag; all 22 CI checks passed; approved and merged |

This PR records the `actions/cache` merge in `CHANGELOG.md` under `[Unreleased]`, following the established pattern.

## Security

- PR #152's cache action SHA (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`) was verified against the upstream `actions/cache` v6.1.0 release commit before merging.
- All 22 CI checks passed on #152, including `Rust Security Audit`, `Cargo Deny` (advisories/bans/licenses/sources), and `CodeQL`.
- No new open pull requests, and no outstanding security-relevant changes remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzG3DUoKLbrdkQFV4wTYhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzG3DUoKLbrdkQFV4wTYhH)_