### PR TITLE
deps: refresh CLI directories and release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.ref }}
           name: Release v${{ steps.extract-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64
         with:
           tag_name: ${{ github.ref }}
           name: Release v${{ steps.extract-version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Updated optional CLI dependency `dirs` from 6.0.0 to 7.0.0 (PR #174, targeting 0.5.8). Its Windows `preference_dir` behavior changed upstream; the CLI uses only unchanged `home_dir` calls, so saved game-stat locations and feature flags are unchanged.
+- Updated `softprops/action-gh-release` from 3.0.2 to 3.0.3 (PR #173, targeting 0.5.8), retaining a full commit SHA pin and adding its release version beside the pin for easier review. Upstream hardens malformed API-error handling and refreshes bundled dependencies; workflow inputs and permissions are unchanged.
 - Updated the `rust-dependencies` group (PR #172, targeting 0.5.8): `zerocopy` 0.8.55 → 0.8.56, `rkyv` 0.8.17 → 0.8.18, `thiserror` 2.0.19 → 2.0.20, `ordered-float` 5.3.0 → 5.5.0, `glam` 0.33.2 → 0.33.6, `crc32fast` 1.5.0 → 1.5.1, `clap` 4.6.5 → 4.6.6, `wgpu` 30.0.0 → 30.0.1, and `cudarc` 0.19.8 → 0.19.9, with their associated lockfile updates. No feature flags changed.
 - Raised the declared minimum Rust version to 1.90, required by `ordered-float` 5.5.0. The previous 1.77 claim was already incompatible with existing dependencies and its CI check silently used the repository's Rust 1.92 pin. CI now explicitly selects the MSRV and stable/beta compilers and tests the locked dependency set. Updated installation guidance and aligned the book's toolchain pin with the repository's Rust 1.92.0.
 - Disabled fail-fast for the Cargo Deny matrix so an advisory failure cannot cancel the independent bans, licenses, and sources check.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
 dependencies = [
  "dirs-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ rustc-hash = "2.1"
 clap = { version = "4.6", features = ["derive"], optional = true }
 rand = { version = "0.10.1", optional = true }
 crossterm = { version = "0.29", optional = true }
-dirs = { version = "6.0", optional = true }
+dirs = { version = "7.0", optional = true }
 
 # Performance: Parallel processing
 rayon = { version = "1.12", optional = true }


### PR DESCRIPTION
## Description
Refresh the optional CLI dependency `dirs` to 7.0.0 and the release action to `softprops/action-gh-release` 3.0.3, with matching Unreleased entries targeting 0.5.8. Consolidates #173 and #174 so both changes are validated together against current main.

## Changes and compatibility
- `dirs` 7 changes Windows `preference_dir`; this repository uses only `home_dir`, whose source is unchanged. No feature flags, game-stat paths, or public APIs change. The published crate checksum matches Cargo.lock, and its only dependency remains `dirs-sys` 0.5.0.
- The release-action SHA resolves to upstream v3.0.3. Reviewed the upstream API-error handling and dependency changes. The full SHA pin remains, with a version annotation to simplify future reviews; inputs and token permissions are unchanged.
- Both original PRs have no review comments or unresolved threads. Existing upstream identities remain; the dirs repository has moved to Codeberg. Public metadata does not fully establish maintainer jurisdiction; no evidence of prohibited control was found in this scoped review.

## Validation
Passed locally in an isolated temporary checkout and Cargo cache:
- `./scripts/safe_local_test.sh --allow-network`: 149 tests and 22 doctests passed; the known slow ESDF test was excluded per policy.
- `cargo test --features cli --bin octaindex3d --locked --offline`: all 4 CLI tests passed.
- `cargo check --all-features --locked --offline`.
- `cargo clippy --all-targets --all-features --locked --offline -- -D warnings`.
- `cargo fmt --all -- --check` and `git diff --check`.

The initial offline attempt lacked dirs 7 in the cache. Local cargo-deny could not lock its configured read-only advisory database, so fresh GitHub security/advisory checks are required before merge. All 26 GitHub checks passed on head `489b860`, including the Rust 1.90 MSRV, Linux/macOS/Windows matrix, GPU jobs, security audits, Cargo Deny, and CodeQL. Automated review completed without findings; there are no unresolved threads.

## Performance and release
No performance-sensitive code changes. This is maintenance for 0.5.8, not a release publication.
