### PR TITLE
release: prepare OctaIndex3D 0.5.8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,9 +185,9 @@ jobs:
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
 
       - name: Build documentation
-        run: cargo doc --no-deps --all-features
+        run: cargo doc --locked --no-deps --all-features
         env:
-          RUSTDOCFLAGS: -D warnings
+          RUSTDOCFLAGS: -D warnings -D missing_docs
 
   audit:
     name: Rust Security Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8] - 2026-09-09
+
 ### Changed
+- Enforced complete public API documentation in CI, refreshed README and book release guidance, and added an immutable-release checklist. README repository links now target this release for reliable rendering on crates.io and docs.rs; local `.claude/` settings are explicitly excluded from packages.
 - Updated optional CLI dependency `dirs` from 6.0.0 to 7.0.0 (PR #174, targeting 0.5.8). Its Windows `preference_dir` behavior changed upstream; the CLI uses only unchanged `home_dir` calls, so saved game-stat locations and feature flags are unchanged.
 - Updated `softprops/action-gh-release` from 3.0.2 to 3.0.3 (PR #173, targeting 0.5.8), retaining a full commit SHA pin and adding its release version beside the pin for easier review. Upstream hardens malformed API-error handling and refreshes bundled dependencies; workflow inputs and permissions are unchanged.
 - Updated the `rust-dependencies` group (PR #172, targeting 0.5.8): `zerocopy` 0.8.55 → 0.8.56, `rkyv` 0.8.17 → 0.8.18, `thiserror` 2.0.19 → 2.0.20, `ordered-float` 5.3.0 → 5.5.0, `glam` 0.33.2 → 0.33.6, `crc32fast` 1.5.0 → 1.5.1, `clap` 4.6.5 → 4.6.6, `wgpu` 30.0.0 → 30.0.1, and `cudarc` 0.19.8 → 0.19.9, with their associated lockfile updates. No feature flags changed.
@@ -339,7 +342,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Morton decode optimization (37% speedup)
 - Parallel overhead fix (86% speedup for 10K batches)
 
-[Unreleased]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.7...HEAD
+[Unreleased]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.8...HEAD
+[0.5.8]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/FunKite/OctaIndex3D/compare/v0.5.4...v0.5.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "octaindex3d"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "ahash",
  "aligned-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octaindex3d"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 rust-version = "1.90"
 authors = ["Michael A. McLarney"]
@@ -14,6 +14,7 @@ keywords = ["spatial", "3d", "indexing", "routing", "bcc-lattice"]
 categories = ["algorithms", "data-structures", "science"]
 build = "build.rs"
 exclude = [
+    ".claude/",
     "docs/",
     "book/",
     "benches/",

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 [![Crates.io](https://img.shields.io/crates/v/octaindex3d.svg)](https://crates.io/crates/octaindex3d)
 [![Documentation](https://docs.rs/octaindex3d/badge.svg)](https://docs.rs/octaindex3d)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.90+-orange.svg)](https://www.rust-lang.org)
 [![CI](https://github.com/FunKite/OctaIndex3D/workflows/Rust%20CI/badge.svg)](https://github.com/FunKite/OctaIndex3D/actions)
 [![Downloads](https://img.shields.io/crates/d/octaindex3d.svg)](https://crates.io/crates/octaindex3d)
 
-[Documentation](https://docs.rs/octaindex3d) | [Book](https://github.com/FunKite/OctaIndex3D/blob/main/book/README.md) | [Crates.io](https://crates.io/crates/octaindex3d) | [Examples](#examples) | [Changelog](CHANGELOG.md)
+[Documentation](https://docs.rs/octaindex3d) | [Book](https://github.com/FunKite/OctaIndex3D/blob/main/book/README.md) | [Crates.io](https://crates.io/crates/octaindex3d) | [Examples](#examples) | [Changelog](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/CHANGELOG.md)
 
 </div>
 
 ## Table of Contents
 
-- [What's New in v0.5.7](#whats-new-in-v057)
+- [What's New in v0.5.8](#whats-new-in-v058)
 - [Overview](#overview)
 - [Why BCC Lattice?](#why-bcc-lattice)
 - [Interactive 3D Maze Game](#-interactive-3d-maze-game)
@@ -34,17 +34,18 @@
 - [Contributing](#contributing)
 - [Research and Citation](#research-and-citation)
 
-## What's New in v0.5.7
+## What's New in v0.5.8
 
-This is a maintenance release focused on dependency currency, a transitive security fix, and CI efficiency. There are no public API changes.
+This maintenance release refreshes dependencies and corrects the minimum supported Rust version. Public APIs and feature flags are unchanged.
 
-- **Security** - Upgraded the transitive `crossbeam-epoch` dependency (pulled in via `rayon`) to 0.9.20 to resolve RUSTSEC-2026-0204, an invalid-pointer-dereference bug in its `fmt::Pointer` impl.
-- **GPU dependency upgrades** - Updated `wgpu` to 30.0.0 and `pollster` to 1.0.1 (both semver-major); the wgpu GPU backend was adjusted for the `RequestAdapterOptions` and `BufferSlice::get_mapped_range` API changes, verified against the full CI matrix including the Vulkan and Metal feature-test jobs.
-- **CI efficiency** - Added cancel-in-progress `concurrency` groups to the `rust.yml`, `security.yml`, and `book-quality.yml` workflows, so new pushes to a branch cancel that branch's still-running CI instead of piling up redundant runs. Added `--locked` to the `cargo-audit` installs so security jobs use a pinned toolchain-compatible version.
-- **Routine dependency maintenance** - Refreshed `bech32`, `cudarc`, `getrandom`, `zerocopy`, `glam`, `bytemuck`, and several GitHub Actions to their latest compatible releases. See the [Changelog](CHANGELOG.md) for the full list.
-- **Documentation coverage** - rustdoc item coverage remains at 100% for complete docs.rs coverage.
+- **Rust 1.90 minimum** — required by the locked dependency set; CI now explicitly tests that compiler instead of silently using the repository's Rust 1.92.0 toolchain.
+- **Dependency updates** — includes `lz4_flex` 0.14, optional CLI `dirs` 7.0, and compatible serialization, GPU, and error-handling updates. CLI saved-game locations are unchanged.
+- **Dependency repair** — replaces yanked transitive `chacha20` 0.10.0 with 0.10.2.
+- **Documentation** — public API documentation is checked across all features with missing documentation and rustdoc warnings treated as errors. The README's Rust examples are tested as doctests.
 
-See the full [Changelog](CHANGELOG.md) for release history.
+The [API reference](https://docs.rs/octaindex3d/0.5.8/octaindex3d/) covers optional features as well as the default API. See the [release checklist](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/docs/RELEASING.md) for package and documentation validation.
+
+See the full [Changelog](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/CHANGELOG.md) for release history.
 
 ## Overview
 
@@ -768,14 +769,14 @@ octaindex3d = { version = "0.5", features = ["container_v2"] }
 ### Getting Help
 
 - **Documentation**: Check [docs.rs/octaindex3d](https://docs.rs/octaindex3d)
-- **Examples**: See the [examples/](examples/) directory
+- **Examples**: See the [examples/](https://github.com/FunKite/OctaIndex3D/tree/v0.5.8/examples/) directory
 - **Issues**: [Open an issue](https://github.com/FunKite/OctaIndex3D/issues) for bugs or feature requests
 - **Discussions**: [GitHub Discussions](https://github.com/FunKite/OctaIndex3D/discussions) for questions
-- **Security**: See [SECURITY.md](SECURITY.md) for reporting vulnerabilities
+- **Security**: See [SECURITY.md](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/SECURITY.md) for reporting vulnerabilities
 
 ## Contributing
 
-Contributions are welcome! Please see our [Contributing Guide](CONTRIBUTING.md) for details on:
+Contributions are welcome! Please see our [Contributing Guide](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/CONTRIBUTING.md) for details on:
 - Code of conduct and community guidelines
 - How to submit bug reports and feature requests
 - Development setup and coding standards
@@ -789,7 +790,7 @@ Feel free to:
 
 ## License
 
-Licensed under the MIT License. See [LICENSE](LICENSE) for details.
+Licensed under the MIT License. See [LICENSE](https://github.com/FunKite/OctaIndex3D/blob/v0.5.8/LICENSE) for details.
 
 ## Research and Citation
 

--- a/book/API_CONTRACT.md
+++ b/book/API_CONTRACT.md
@@ -11,6 +11,7 @@ container_v2
 error
 frame
 geojson
+grid
 hilbert
 id
 ids
@@ -31,6 +32,7 @@ crate::container_v2::{ContainerWriterV2, HeaderV2, StreamConfig}
 crate::error::{Error, Result}
 crate::frame::{get_frame, list_frames, register_frame, FrameDescriptor}
 crate::geojson::{
+crate::grid::{BccGrid, GridPath}
 crate::hilbert::Hilbert64
 crate::id::CellID
 crate::ids::{FrameId, Galactic128, Index64, Route64}

--- a/book/README.md
+++ b/book/README.md
@@ -5,6 +5,7 @@
 **Authors**: Michael A. McLarney, GPT-5.1 (OpenAI), and Claude (Anthropic)  
 **Edition**: First Edition, 2025  
 **Status**: Core Draft Complete and Continuously Updated
+**Current library release**: 0.5.8 — Rust 1.90 minimum; development toolchain 1.92.0. This maintenance release preserves public APIs and feature flags. See the [changelog](../CHANGELOG.md) and [versioned API reference](https://docs.rs/octaindex3d/0.5.8/octaindex3d/).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 # OctaIndex3D Documentation
 
-This directory contains documentation for the OctaIndex3D project.
+This directory contains documentation for OctaIndex3D 0.5.8 (Rust 1.90 minimum; development toolchain 1.92.0). Public APIs and feature flags are unchanged in this maintenance release.
+
+The [versioned API reference](https://docs.rs/octaindex3d/0.5.8/octaindex3d/) documents all features. The README is included in the crates.io package; this directory and the book are maintained on GitHub.
 
 ## Whitepaper
 
@@ -37,6 +39,7 @@ If you use OctaIndex3D in your research, please cite:
 - [GAME_ENHANCEMENTS.md](GAME_ENHANCEMENTS.md) - Game development features
 
 ### Development
+- [RELEASING.md](RELEASING.md) - Immutable release checklist and documentation validation
 - [CODE_REVIEW_REPORT.md](CODE_REVIEW_REPORT.md) - Code quality analysis
 - [SAFE_LOCAL_TESTING.md](SAFE_LOCAL_TESTING.md) - Safer local test workflow for dependency and PR validation
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,16 @@
+# Release checklist
+
+crates.io versions are immutable. Prepare changes on a short-lived branch, merge through a reviewed PR with passing checks, and publish from the merged commit. Never tag before successful publication.
+
+1. Confirm the proposed version is absent from the crates.io index and GitHub tags/releases. Review open PRs, dependency changes, and security alerts.
+2. Update `Cargo.toml`, the root package in `Cargo.lock`, the version assertion in `src/lib.rs`, README highlights and versioned links, the documentation index, and book release guidance. Move changelog entries into a dated release section and update comparison links.
+3. Run `./scripts/safe_local_test.sh` (use `--allow-network` if the locked dependencies are not cached), formatting, all-feature checking, Clippy, and feature-matrix CI. Review any skipped hardware/slow tests explicitly.
+4. Run `RUSTDOCFLAGS="-D warnings -D missing_docs" cargo doc --locked --all-features --no-deps` and the equivalent no-default-feature check. Run doctests, including the README examples. CI enforces the all-feature documentation gate.
+5. With an existing nightly toolchain, measure item coverage using `cargo +nightly rustdoc --locked --all-features --lib -- -Z unstable-options --show-coverage`. Require 100% documented items; this metric does not mean every item has a runnable example. docs.rs builds the published package with all features, on nightly, including platform-specific target variants.
+6. Inspect `cargo package --locked --list`: source, build script, README, changelog, and license must be present; credentials, local settings, and internal artifacts must be absent. Repository links in the README must be absolute and release-versioned because registry rendering has a different base URL.
+7. After merging and synchronizing `main`, run `cargo publish --locked --dry-run` without `--allow-dirty` or `--no-verify`. Inspect and test documentation from the extracted `target/package/octaindex3d-VERSION` package, not just the checkout. Record the commit and package checksum.
+8. Run `cargo publish --locked` from that same commit. If upload status is ambiguous, check the registry before retrying. Verify the version and checksum in the crates.io index.
+9. Create an annotated `vVERSION` tag at the published commit and push it. The release workflow creates the GitHub Release; update its notes with the version's changelog and validation results.
+10. Verify the crates.io version, GitHub tag/release, and successful docs.rs build with 100% documented-item coverage. A queued docs.rs build is pending verification, not a confirmed success.
+
+No new tools are required for the stable documentation gate. The release process must preserve the locked dependency set and must not bypass protected-branch checks.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(VERSION, "0.5.7");
+        assert_eq!(VERSION, "0.5.8");
     }
 
     #[test]


### PR DESCRIPTION
Prepare OctaIndex3D 0.5.8 for publication. This release includes the dependency and MSRV maintenance already on main, without changing public APIs or feature flags.

Updates the package/lockfile version, version test, dated changelog, README release notes and registry-safe links, documentation index, book guidance, and generated API contract. Adds an immutable-release checklist and explicitly excludes local `.claude/` settings from the crate. CI now rejects missing public API documentation across all features.

Validation: guarded default tests (149 passed, known slow ESDF test skipped), 22 README/API doctests, all-feature check, all-target/all-feature Clippy, formatting, book checks, and strict all-feature/no-default-feature documentation builds passed. Installed nightly rustdoc reports 793/793 public items documented (100%). The local cargo-deny version cannot parse CVSS 4.0; GitHub security gates remain required. Full feature tests and publish-package validation are also being run before publication.

After required checks and review pass, publish from merged main only after `cargo publish --locked --dry-run`; verify registry publication before tagging v0.5.8 and creating the GitHub release.
